### PR TITLE
fix: pylint misconfiguration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def pylint(session: nox.Session) -> None:
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
     session.install(".", "pylint")
-    session.run("pylint", "src", *session.posargs)
+    session.run("pylint", "se_for_sci_hw4", *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,9 @@ warn_unreachable = true
 
 
 [tool.pylint]
-master.py-version = "3.7"
-master.ignore-paths= ["src/se_for_sci_hw4/_version.py"]
+py-version = "3.7"
+ignore-paths= ["src/se_for_sci_hw4/_version.py"]
+extension-pkg-allow-list = ["se_for_sci_hw4._core"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 messages_control.disable = [
@@ -83,4 +84,5 @@ messages_control.disable = [
   "fixme",
   "line-too-long",
   "wrong-import-position",
+  "missing-module-docstring",
 ]


### PR DESCRIPTION
Pylint is a little tricky to configure correctly for a compiled extension; I forget it would run in the CI so I didn't configure it. This configures it correctly to make it pass.

(CI on this PR will fail since I don't have the solution in it ;) )
